### PR TITLE
[SLIMDETOURS] Flush trampoline->rbCodeIn correctly

### DIFF
--- a/Source/SlimDetours/Transaction.c
+++ b/Source/SlimDetours/Transaction.c
@@ -190,7 +190,7 @@ SlimDetoursTransactionCommit(VOID)
 
 #if defined(_AMD64_)
             pbCode = detour_gen_jmp_indirect(o->pTrampoline->rbCodeIn, &o->pTrampoline->pbDetour);
-            NtFlushInstructionCache(NtCurrentProcess(), pbCode, pbCode - o->pTrampoline->rbCodeIn);
+            NtFlushInstructionCache(NtCurrentProcess(), o->pTrampoline->rbCodeIn, pbCode - o->pTrampoline->rbCodeIn);
             pbCode = detour_gen_jmp_immediate(o->pbTarget, o->pTrampoline->rbCodeIn);
 #elif defined(_X86_)
             pbCode = detour_gen_jmp_immediate(o->pbTarget, o->pTrampoline->pbDetour);


### PR DESCRIPTION
Before this change, the instruction *after* the jmp was flushed rather than the jmp itself.