### PR TITLE
[INLINEHOOK] Update thread PC if it in `rbCodeIn` when unhooking on x64 platform

### DIFF
--- a/Source/SlimDetours/Thread.c
+++ b/Source/SlimDetours/Thread.c
@@ -154,6 +154,13 @@ detour_thread_update(
                     detour_align_from_trampoline(o->pTrampoline, (BYTE)(cxt.CONTEXT_PC - (ULONG_PTR)o->pTrampoline));
                 bUpdateContext = TRUE;
             }
+#if defined(_AMD64_)
+            else if (cxt.CONTEXT_PC == (ULONG_PTR)o->pTrampoline->rbCodeIn)
+            {
+                cxt.CONTEXT_PC = (ULONG_PTR)o->pbTarget;
+                bUpdateContext = TRUE;
+            }
+#endif
         } else
         {
             if (cxt.CONTEXT_PC >= (ULONG_PTR)o->pbTarget &&


### PR DESCRIPTION
Details about this edge case discussed in https://github.com/KNSoft/KNSoft.SlimDetours/commit/35aa2ca8a5a3a6bdd087923754a14ba02ccde9aa