### PR TITLE
When unhooking, verify that the function wasn't changed

### DIFF
--- a/Source/SlimDetours/Instruction.c
+++ b/Source/SlimDetours/Instruction.c
@@ -121,6 +121,20 @@ detour_gen_jmp_immediate(
     return pbCode + sizeof(INT32);
 }
 
+BOOL
+detour_is_jmp_immediate_to(
+    _In_ PBYTE pbCode,
+    _In_ PBYTE pbJmpVal)
+{
+    PBYTE pbJmpSrc = pbCode + 5;
+    if (*pbCode++ != 0xe9)   // jmp +imm32
+    {
+        return FALSE;
+    }
+    INT32 offset = *((INT32*)pbCode);
+    return offset == (INT32)(pbJmpVal - pbJmpSrc);
+}
+
 _Ret_notnull_
 PBYTE
 detour_gen_jmp_indirect(
@@ -138,6 +152,30 @@ detour_gen_jmp_indirect(
     *((INT32*)pbCode) = (INT32)((PBYTE)ppbJmpVal);
 #endif
     return pbCode + sizeof(INT32);
+}
+
+BOOL
+detour_is_jmp_indirect_to(
+    _In_ PBYTE pbCode,
+    _In_ PBYTE* ppbJmpVal)
+{
+#if defined(_AMD64_)
+    PBYTE pbJmpSrc = pbCode + 6;
+#endif
+    if (*pbCode++ != 0xff)   // jmp [+imm32]
+    {
+        return FALSE;
+    }
+    if (*pbCode++ != 0x25)
+    {
+        return FALSE;
+    }
+    INT32 offset = *((INT32*)pbCode);
+#if defined(_AMD64_)
+    return offset == (INT32)((PBYTE)ppbJmpVal - pbJmpSrc);
+#else
+    return offset == (INT32)((PBYTE)ppbJmpVal);
+#endif
 }
 
 _Ret_notnull_
@@ -487,6 +525,37 @@ detour_gen_jmp_indirect(
     pIndJmp->br = 0xD61F0220;
 
     return pbCode;
+}
+
+BOOL
+detour_is_jmp_indirect_to(
+    _In_ PBYTE pbCode,
+    _In_ PULONG64 pbJmpVal)
+{
+    const struct ARM64_INDIRECT_JMP* pIndJmp;
+    union ARM64_INDIRECT_IMM jmpIndAddr;
+
+    jmpIndAddr.value = (((LONG64)pbJmpVal) & 0xFFFFFFFFFFFFF000) -
+        (((LONG64)pbCode) & 0xFFFFFFFFFFFFF000);
+
+    pIndJmp = (const struct ARM64_INDIRECT_JMP*)pbCode;
+
+    return pIndJmp->ardp.Rd == 17 &&
+        pIndJmp->ardp.immhi == (ULONG)jmpIndAddr.adrp_immhi &&
+        pIndJmp->ardp.iop == 0x10 &&
+        pIndJmp->ardp.immlo == (ULONG)jmpIndAddr.adrp_immlo &&
+        pIndJmp->ardp.op == 1 &&
+
+        pIndJmp->ldr.Rt == 17 &&
+        pIndJmp->ldr.Rn == 17 &&
+        pIndJmp->ldr.imm == (((ULONG64)pbJmpVal) & 0xFFF) / 8 &&
+        pIndJmp->ldr.opc == 1 &&
+        pIndJmp->ldr.iop1 == 1 &&
+        pIndJmp->ldr.V == 0 &&
+        pIndJmp->ldr.iop2 == 7 &&
+        pIndJmp->ldr.size == 3 &&
+
+        pIndJmp->br == 0xD61F0220;
 }
 
 _Ret_notnull_

--- a/Source/SlimDetours/SlimDetours.inl
+++ b/Source/SlimDetours/SlimDetours.inl
@@ -87,13 +87,13 @@ typedef struct _DETOUR_TRAMPOLINE
     DETOUR_ALIGN    rAlign[8];          // instruction alignment array.
     PBYTE           pbRemain;           // first instruction after moved code. [free list]
     PBYTE           pbDetour;           // first instruction of detour function.
-#if defined(_AMD64_)
+#if defined(_X86_) || defined(_AMD64_)
     BYTE            rbCodeIn[8];        // jmp [pbDetour]
 #endif
 } DETOUR_TRAMPOLINE, *PDETOUR_TRAMPOLINE;
 
 #if defined(_X86_)
-_STATIC_ASSERT(sizeof(DETOUR_TRAMPOLINE) == 72);
+_STATIC_ASSERT(sizeof(DETOUR_TRAMPOLINE) == 80);
 #elif defined(_AMD64_)
 _STATIC_ASSERT(sizeof(DETOUR_TRAMPOLINE) == 96);
 #elif defined(_ARM64_)

--- a/Source/SlimDetours/SlimDetours.inl
+++ b/Source/SlimDetours/SlimDetours.inl
@@ -105,7 +105,8 @@ typedef struct _DETOUR_OPERATION DETOUR_OPERATION, *PDETOUR_OPERATION;
 struct _DETOUR_OPERATION
 {
     PDETOUR_OPERATION pNext;
-    BOOL fIsRemove;
+    BOOL fIsAdd : 1;
+    BOOL fIsRemove : 1;
     PBYTE* ppbPointer;
     PBYTE pbTarget;
     PDETOUR_TRAMPOLINE pTrampoline;
@@ -158,9 +159,19 @@ detour_gen_jmp_immediate(
     _In_ PBYTE pbCode,
     _In_ PBYTE pbJmpVal);
 
+BOOL
+detour_is_jmp_immediate_to(
+    _In_ PBYTE pbCode,
+    _In_ PBYTE pbJmpVal);
+
 _Ret_notnull_
 PBYTE
 detour_gen_jmp_indirect(
+    _In_ PBYTE pbCode,
+    _In_ PBYTE* ppbJmpVal);
+
+BOOL
+detour_is_jmp_indirect_to(
     _In_ PBYTE pbCode,
     _In_ PBYTE* ppbJmpVal);
 
@@ -176,6 +187,11 @@ detour_gen_jmp_immediate(
 _Ret_notnull_
 PBYTE
 detour_gen_jmp_indirect(
+    _In_ PBYTE pbCode,
+    _In_ PULONG64 pbJmpVal);
+
+BOOL
+detour_is_jmp_indirect_to(
     _In_ PBYTE pbCode,
     _In_ PULONG64 pbJmpVal);
 

--- a/Source/SlimDetours/Thread.c
+++ b/Source/SlimDetours/Thread.c
@@ -142,9 +142,9 @@ detour_thread_update(
         return Status;
     }
 
-    for (o = PendingOperations; o != NULL; o = o->pNext)
+    bUpdateContext = FALSE;
+    for (o = PendingOperations; o != NULL && !bUpdateContext; o = o->pNext)
     {
-        bUpdateContext = FALSE;
         if (o->fIsRemove)
         {
             if (cxt.CONTEXT_PC >= (ULONG_PTR)o->pTrampoline->rbCode &&
@@ -161,7 +161,7 @@ detour_thread_update(
                 bUpdateContext = TRUE;
             }
 #endif
-        } else
+        } else if (o->fIsAdd)
         {
             if (cxt.CONTEXT_PC >= (ULONG_PTR)o->pbTarget &&
                 cxt.CONTEXT_PC < ((ULONG_PTR)o->pbTarget + o->pTrampoline->cbRestore))
@@ -171,11 +171,11 @@ detour_thread_update(
                 bUpdateContext = TRUE;
             }
         }
-        if (bUpdateContext)
-        {
-            Status = NtSetContextThread(ThreadHandle, &cxt);
-            break;
-        }
+    }
+
+    if (bUpdateContext)
+    {
+        Status = NtSetContextThread(ThreadHandle, &cxt);
     }
 
     return Status;

--- a/Source/SlimDetours/Thread.c
+++ b/Source/SlimDetours/Thread.c
@@ -154,7 +154,7 @@ detour_thread_update(
                     detour_align_from_trampoline(o->pTrampoline, (BYTE)(cxt.CONTEXT_PC - (ULONG_PTR)o->pTrampoline));
                 bUpdateContext = TRUE;
             }
-#if defined(_AMD64_)
+#if defined(_X86_) || defined(_AMD64_)
             else if (cxt.CONTEXT_PC == (ULONG_PTR)o->pTrampoline->rbCodeIn)
             {
                 cxt.CONTEXT_PC = (ULONG_PTR)o->pbTarget;

--- a/Source/SlimDetours/Transaction.c
+++ b/Source/SlimDetours/Transaction.c
@@ -188,12 +188,10 @@ SlimDetoursTransactionCommit(VOID)
                          o->pbTarget[4], o->pbTarget[5], o->pbTarget[6], o->pbTarget[7],
                          o->pbTarget[8], o->pbTarget[9], o->pbTarget[10], o->pbTarget[11]);
 
-#if defined(_AMD64_)
+#if defined(_X86_) || defined(_AMD64_)
             pbCode = detour_gen_jmp_indirect(o->pTrampoline->rbCodeIn, &o->pTrampoline->pbDetour);
             NtFlushInstructionCache(NtCurrentProcess(), o->pTrampoline->rbCodeIn, pbCode - o->pTrampoline->rbCodeIn);
             pbCode = detour_gen_jmp_immediate(o->pbTarget, o->pTrampoline->rbCodeIn);
-#elif defined(_X86_)
-            pbCode = detour_gen_jmp_immediate(o->pbTarget, o->pTrampoline->pbDetour);
 #elif defined(_ARM64_)
             pbCode = detour_gen_jmp_indirect(o->pbTarget, (ULONG64*)&(o->pTrampoline->pbDetour));
 #endif

--- a/Source/SlimDetours/Transaction.c
+++ b/Source/SlimDetours/Transaction.c
@@ -111,7 +111,7 @@ SlimDetoursTransactionAbort(VOID)
         pMem = o->pbTarget;
         sMem = o->pTrampoline->cbRestore;
         NtProtectVirtualMemory(NtCurrentProcess(), &pMem, &sMem, o->dwPerm, &dwOld);
-        if (!o->fIsRemove)
+        if (o->fIsAdd)
         {
             if (o->pTrampoline)
             {
@@ -168,10 +168,29 @@ SlimDetoursTransactionCommit(VOID)
     {
         if (o->fIsRemove)
         {
-            RtlCopyMemory(o->pbTarget, o->pTrampoline->rbRestore, o->pTrampoline->cbRestore);
-            NtFlushInstructionCache(NtCurrentProcess(), o->pbTarget, o->pTrampoline->cbRestore);
+            // Check if the jmps still points where we expect, otherwise someone might have hooked us.
+            BOOL hookIsStillThere =
+#if defined(_X86_) || defined(_AMD64_)
+                detour_is_jmp_immediate_to(o->pbTarget, o->pTrampoline->rbCodeIn) &&
+                detour_is_jmp_indirect_to(o->pTrampoline->rbCodeIn, &o->pTrampoline->pbDetour);
+#elif defined(_ARM64_)
+                detour_is_jmp_indirect_to(o->pbTarget, (ULONG64*)&(o->pTrampoline->pbDetour));
+#endif
+
+            if (hookIsStillThere)
+            {
+                RtlCopyMemory(o->pbTarget, o->pTrampoline->rbRestore, o->pTrampoline->cbRestore);
+                NtFlushInstructionCache(NtCurrentProcess(), o->pbTarget, o->pTrampoline->cbRestore);
+            } else
+            {
+                // Don't remove in this case, put in bypass mode and leak trampoline.
+                o->fIsRemove = FALSE;
+                o->pTrampoline->pbDetour = o->pTrampoline->rbCode;
+                DETOUR_TRACE("detours: Leaked hook on pbTarget=%p due to external hooking\n", o->pbTarget);
+            }
+
             *o->ppbPointer = o->pbTarget;
-        } else
+        } else if (o->fIsAdd)
         {
             DETOUR_TRACE("detours: pbTramp =%p, pbRemain=%p, pbDetour=%p, cbRestore=%u\n",
                          o->pTrampoline,
@@ -460,6 +479,7 @@ fail:
                  pTrampoline->rbCode[8], pTrampoline->rbCode[9],
                  pTrampoline->rbCode[10], pTrampoline->rbCode[11]);
 
+    o->fIsAdd = TRUE;
     o->fIsRemove = FALSE;
     o->ppbPointer = (PBYTE*)ppPointer;
     o->pTrampoline = pTrampoline;
@@ -523,6 +543,7 @@ fail:
         goto fail;
     }
 
+    o->fIsAdd = FALSE;
     o->fIsRemove = TRUE;
     o->ppbPointer = (PBYTE*)ppPointer;
     o->pTrampoline = pTrampoline;


### PR DESCRIPTION
I believe that the tradeoff - extra 8 bytes in x86 and trading a UB/crash for a tiny leak - is very well worth it.