### PR TITLE
Add SlimDetoursUninitialize to be able to destroy the created heap

### DIFF
--- a/Source/SlimDetours/Memory.c
+++ b/Source/SlimDetours/Memory.c
@@ -142,6 +142,18 @@ detour_memory_free(
 }
 
 BOOL
+detour_memory_uninitialize(VOID)
+{
+    if (_detour_memory_heap != NULL && _detour_memory_heap != NtGetProcessHeap())
+    {
+        _detour_memory_heap = RtlDestroyHeap(_detour_memory_heap);
+        return _detour_memory_heap == NULL;
+    }
+
+    return TRUE;
+}
+
+BOOL
 detour_memory_is_system_reserved(
     _In_ PVOID Address)
 {

--- a/Source/SlimDetours/SlimDetours.h
+++ b/Source/SlimDetours/SlimDetours.h
@@ -64,6 +64,10 @@ SlimDetoursCopyInstruction(
     _Out_opt_ PVOID* ppTarget,
     _Out_opt_ LONG* plExtra);
 
+HRESULT
+NTAPI
+SlimDetoursUninitialize(VOID);
+
 /* Inline Hook, base on Detours */
 
 /// <summary>

--- a/Source/SlimDetours/SlimDetours.inl
+++ b/Source/SlimDetours/SlimDetours.inl
@@ -135,6 +135,9 @@ detour_memory_free(
     _Frees_ptr_ PVOID BaseAddress);
 
 BOOL
+detour_memory_uninitialize(VOID);
+
+BOOL
 detour_memory_is_system_reserved(
     _In_ PVOID Address);
 

--- a/Source/SlimDetours/Transaction.c
+++ b/Source/SlimDetours/Transaction.c
@@ -552,6 +552,20 @@ fail:
     return HRESULT_FROM_NT(STATUS_SUCCESS);
 }
 
+HRESULT
+NTAPI
+SlimDetoursUninitialize(VOID)
+{
+    NTSTATUS Status = STATUS_SUCCESS;
+
+    if (!detour_memory_uninitialize())
+    {
+        Status = STATUS_INVALID_HANDLE;
+    }
+
+    return HRESULT_FROM_NT(Status);
+}
+
 #if (NTDDI_VERSION >= NTDDI_WIN6)
 
 static


### PR DESCRIPTION
Otherwise, if loaded and unloaded multiple times, a new heap will be created each time, which is suboptimal.