### PR TITLE
Add SlimDetoursTransactionBeginEx to allow skipping thread suspending

### DIFF
--- a/Source/SlimDetours/SlimDetours.h
+++ b/Source/SlimDetours/SlimDetours.h
@@ -27,9 +27,26 @@ extern "C" {
 #define DETOUR_INSTRUCTION_TARGET_NONE ((PVOID)0)
 #define DETOUR_INSTRUCTION_TARGET_DYNAMIC ((PVOID)(LONG_PTR)-1)
 
+typedef struct _DETOUR_TRANSACTION_OPTIONS
+{
+    BOOL fSuspendThreads;
+} DETOUR_TRANSACTION_OPTIONS, *PDETOUR_TRANSACTION_OPTIONS;
+
+typedef const DETOUR_TRANSACTION_OPTIONS* PCDETOUR_TRANSACTION_OPTIONS;
+
 HRESULT
 NTAPI
-SlimDetoursTransactionBegin(VOID);
+SlimDetoursTransactionBeginEx(
+    _In_ PCDETOUR_TRANSACTION_OPTIONS pOptions);
+
+FORCEINLINE
+HRESULT
+SlimDetoursTransactionBegin(VOID)
+{
+    DETOUR_TRANSACTION_OPTIONS Options;
+    Options.fSuspendThreads = TRUE;
+    return SlimDetoursTransactionBeginEx(&Options);
+}
 
 HRESULT
 NTAPI


### PR DESCRIPTION
In some cases, suspending threads isn't necessary. For example, when a module was just loaded and it's guaranteed that the target function can't be running.