### PR TITLE
Graceful handling for invalid target function

### DIFF
--- a/Source/KNSoft.SlimDetours/Disassembler.c
+++ b/Source/KNSoft.SlimDetours/Disassembler.c
@@ -1058,9 +1058,9 @@ Invalid(
     UNREFERENCED_PARAMETER(pDisasm);
     UNREFERENCED_PARAMETER(pEntry);
     UNREFERENCED_PARAMETER(pbDst);
+    UNREFERENCED_PARAMETER(pbSrc);
 
-    ASSERT(!"Invalid Instruction");
-    return pbSrc + 1;
+    return NULL;
 }
 
 static

--- a/Source/KNSoft.SlimDetours/Disassembler.c
+++ b/Source/KNSoft.SlimDetours/Disassembler.c
@@ -1490,10 +1490,14 @@ CopyFF(
     // invalid/7
     UNREFERENCED_PARAMETER(pEntry);
 
+    BYTE const b1 = pbSrc[1];
+    if ((b1 & 0x38) == 0x38)
+    {
+        return Invalid(pDisasm, &g_rceCopyMap[eENTRY_Invalid], pbDst, pbSrc);
+    }
+
     REFCOPYENTRY ce = /* ff */ &g_rceCopyMap[eENTRY_CopyBytes2Mod];
     PBYTE pbOut = ce->pfCopy(pDisasm, ce, pbDst, pbSrc);
-
-    BYTE const b1 = pbSrc[1];
 
     if (0x15 == b1 || 0x25 == b1)
     {

--- a/Source/KNSoft.SlimDetours/Disassembler.c
+++ b/Source/KNSoft.SlimDetours/Disassembler.c
@@ -2685,6 +2685,7 @@ CopyInstruction(
 
 #endif // defined(_ARM64_)
 
+_Success_(return != NULL)
 PVOID
 NTAPI
 SlimDetoursCopyInstruction(

--- a/Source/KNSoft.SlimDetours/SlimDetours.h
+++ b/Source/KNSoft.SlimDetours/SlimDetours.h
@@ -73,6 +73,7 @@ NTAPI
 SlimDetoursCodeFromPointer(
     _In_ PVOID pPointer);
 
+_Success_(return != NULL)
 PVOID
 NTAPI
 SlimDetoursCopyInstruction(

--- a/Source/KNSoft.SlimDetours/Transaction.c
+++ b/Source/KNSoft.SlimDetours/Transaction.c
@@ -345,6 +345,13 @@ fail:
 
         DETOUR_TRACE(" SlimDetoursCopyInstruction(%p,%p)\n", pbTrampoline, pbSrc);
         pbSrc = (PBYTE)SlimDetoursCopyInstruction(pbTrampoline, pbSrc, NULL, &lExtra);
+        if (pbSrc == NULL)
+        {
+            Status = STATUS_ILLEGAL_INSTRUCTION;
+            DETOUR_BREAK();
+            goto fail;
+        }
+
         DETOUR_TRACE(" SlimDetoursCopyInstruction() = %p (%d bytes)\n", pbSrc, (int)(pbSrc - pbOp));
         pbTrampoline += (pbSrc - pbOp) + lExtra;
         cbTarget = PtrOffset(pbTarget, pbSrc);


### PR DESCRIPTION
Fixes #14.

Note that this fix is not 100% complete. For example, the x64 command `FF 01` is valid, but `FF FF` isn't. Still, both are reported as 2-byte commands.

I'm not an assembly guru, but this comment:
https://github.com/KNSoft/KNSoft.SlimDetours/blob/4cc236ae98ef10788da7a2b08aaf3bf660281bca/Source/SlimDetours/Disassembler.c#L1490

Makes me think that perhaps a check like ~`if (b1 & 0x80) return NULL;`~ (edit: probably `if ((b1 & 0x38) == 0x38) return NULL;`) will cover this case and similar cases where this comment is found.

I don't know if other adjustments are required, and I didn't want to make changes in these sensitive areas which I don't fully understand.