### PR TITLE
Fix detour_does_code_end_function for ARM64

### DIFF
--- a/Source/SlimDetours/Instruction.c
+++ b/Source/SlimDetours/Instruction.c
@@ -767,15 +767,15 @@ BOOL
 detour_does_code_end_function(
     _In_ PBYTE pbCode)
 {
-    ULONG Opcode = fetch_opcode(pbCode);
-
     // When the OS has patched a function entry point, it will incorrectly
     // appear as though the function is just a single branch instruction.
     if (detour_is_code_os_patched(pbCode))
     {
         return FALSE;
     }
-    if ((Opcode & 0xfffffc1f) == 0xd65f0000 ||  // br <reg>
+
+    ULONG Opcode = fetch_opcode(pbCode);
+    if ((Opcode & 0xffbffc1f) == 0xd61f0000 ||  // ret/br <reg>
         (Opcode & 0xfc000000) == 0x14000000)    // b <imm26>
     {
         return TRUE;


### PR DESCRIPTION
It incorrectly returned FALSE for `br <reg>` instructions. The previous check (`(Opcode & 0xfffffc1f) == 0xd65f0000`) only matched `ret <reg>` instructions, despite the incorrect comment.

Upstream PR: https://github.com/microsoft/Detours/pull/348.

The fix was found while trying to hook a function which is already hooked by [funchook](https://github.com/kubo/funchook):

![image](https://github.com/user-attachments/assets/cbb2fbc4-363b-4779-a96c-200af4aa6d5b)

As seen on the screenshot, funchook uses only two instructions for the hook, while Detours uses three. Because of the incorrect check, SlimDetours was overriding the third command too, causing funhook's original function pointer to land at `br xip1` and cause a crash:

![image](https://github.com/user-attachments/assets/1f1de57f-2c93-4028-9cf6-8d8d12a162a1)

With this fix, trying to hook such functions will fail, which is not ideal, but at least it won't crash.