### PR TITLE
[MEMORY] Initialize before thread updating

### DIFF
--- a/Source/SlimDetours/SlimDetours.inl
+++ b/Source/SlimDetours/SlimDetours.inl
@@ -111,6 +111,9 @@ struct _DETOUR_OPERATION
 
 /* Memory management */
 
+VOID
+detour_memory_init(VOID);
+
 _Must_inspect_result_
 _Ret_maybenull_
 _Post_writable_byte_size_(Size)

--- a/Source/SlimDetours/Transaction.c
+++ b/Source/SlimDetours/Transaction.c
@@ -30,6 +30,9 @@ SlimDetoursTransactionBeginEx(
         return HRESULT_FROM_NT(STATUS_TRANSACTIONAL_CONFLICT);
     }
 
+    // Initialize memory management
+    detour_memory_init();
+
     // Make sure the trampoline pages are writable.
     Status = detour_writable_trampoline_regions();
     if (!NT_SUCCESS(Status))


### PR DESCRIPTION
Initialize memory management when transcation starts. Before this PR, memory management was initialized during thread updates, which could lead to a deadlock.

Fix issue: #23 